### PR TITLE
Update config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/cavaliere78/ha_minidlna",
     "startup": "services",
     "boot": "auto",
+    "init": "false",
     "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
     "ports": {
               "1900/udp": 1900


### PR DESCRIPTION
Add init:false to avoid error   " s6-overlay-suexec: fatal: can only run as pid 1" as per https://community.home-assistant.io/t/s6-overlay-suexec-fatal-can-only-run-as-pid-1-error-when-starting-ring-livestream/448456